### PR TITLE
Adds API key as an optional config for https requests

### DIFF
--- a/dialogs/iframely.js
+++ b/dialogs/iframely.js
@@ -29,6 +29,7 @@
 
         var hostname = 'http://iframe.ly';
         var method = 'oembed';
+        var api_key = null;
 
         if (typeof editor.config.iframely === 'undefined') {
           editor.config.iframely = {};
@@ -40,6 +41,10 @@
 
         if (typeof editor.config.iframely.method !== 'undefined') {
           method = editor.config.iframely.method;
+        }
+
+        if (typeof editor.config.iframely.api_key !== 'undefined') {
+          api_key = editor.config.iframely.api_key;
         }
 
         var endpoint = hostname + '/api/' + method;


### PR DESCRIPTION
#### What's this PR do?

This PR adds api_key as one of the available parameters to be read in from the ckeditor config to allow for API requests.

#### Where should the reviewer start?

Start with a ckeditor instance with this plugin from this branch enabled.  The config for this plugin should look as follows:

```
  config.iframely = {
    method: 'iframely',
    endpoint: 'https://[namespace].iframe.ly',
    embed_key: {
      instagram: 'links.app.0.html',
      thedailyshow: 'links.player.0.html'
    },
    api_key: '[valid API key]'
  };
```

#### How should this be manually tested?

##### Before
- [ ] Attempt to embed a twitter URL - you should see a 403 in the browser's console.

##### After
- [ ] Attempt the same - you should get a valid embed.

#### Checklist:
- [ ] Code standard review
- [ ] Tests included
- [ ] Documentation provided
- [ ] End user documentation provided

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch