### PR TITLE
Async Iframely Dialog Handler

### DIFF
--- a/dialogs/iframely.js
+++ b/dialogs/iframely.js
@@ -1,9 +1,8 @@
-(function(){
-  'use strict';
+(function () {
+  'use strict'
 
   CKEDITOR.dialog.add( 'iframelyDialog', function ( editor ) {
-
-    var dialog = CKEDITOR.dialog;
+    var dialog = CKEDITOR.dialog
 
     return {
       title: 'Embed via iframely',
@@ -23,113 +22,98 @@
           ]
         }
       ],
-      onOk: function() {
-
+      onOk: function () {
         // @todo add a default configuration object.
 
-        var hostname = 'http://iframe.ly';
-        var method = 'oembed';
-        var api_key = null;
+        var hostname = 'http://iframe.ly'
+        var method = 'oembed'
+        var api_key = null
 
         if (typeof editor.config.iframely === 'undefined') {
-          editor.config.iframely = {};
+          editor.config.iframely = {}
         }
 
         if (typeof editor.config.iframely.endpoint !== 'undefined') {
-          hostname = editor.config.iframely.endpoint;
+          hostname = editor.config.iframely.endpoint
         }
 
         if (typeof editor.config.iframely.method !== 'undefined') {
-          method = editor.config.iframely.method;
+          method = editor.config.iframely.method
         }
 
         if (typeof editor.config.iframely.api_key !== 'undefined') {
-          api_key = editor.config.iframely.api_key;
+          api_key = editor.config.iframely.api_key
         }
 
-        var endpoint = hostname + '/api/' + method;
-        var provider = '';
+        var endpoint = hostname + '/api/' + method
+        var provider = ''
 
         var query = [
-          'url=' + encodeURIComponent(this.getValueOf( 'iframely-embed', 'url' ))
-        ];
+          'url=' + encodeURIComponent(this.getValueOf('iframely-embed', 'url'))
+        ]
 
-        for(var config in editor.config.iframely) {
-          if(editor.config.iframely.hasOwnProperty(config)) {
-            switch(config) {
+        for (var config in editor.config.iframely) {
+          if (editor.config.iframely.hasOwnProperty(config)) {
+            switch (config) {
               case 'method':
               case 'endpoint':
               case 'embed_key':
-                continue;
+                continue
               default:
-                query.push(config + '=' + editor.config.iframely[config]);
-                break;
+                query.push(config + '=' + editor.config.iframely[config])
+                break
             }
           }
         }
 
-        endpoint += '?' + query.join('&');
-        jQuery.get(endpoint, function(json) {
-          var html = json.html;
+        endpoint += '?' + query.join('&')
+        jQuery.get(endpoint, function (json) {
+          var html = json.html
 
           if (editor.config.iframely.method === 'iframely') {
             if (typeof json.meta.site !== 'undefined') {
-              provider = json.meta.site.toLowerCase();
-            }
-            else {
+              provider = json.meta.site.toLowerCase()
+            } else {
               if (typeof json.meta.author !== 'undefined') {
-                provider = json.meta.author.toLowerCase();
+                provider = json.meta.author.toLowerCase()
               }
             }
 
             if (typeof editor.config.iframely.embed_key !== 'undefined') {
-              var embed_key = editor.config.iframely.embed_key;
+              var embed_key = editor.config.iframely.embed_key
               if (embed_key.hasOwnProperty(provider)) {
-                var buff = json;
-                var pieces = embed_key[provider].split(".");
-                for(var i=0; i< pieces.length; i++) {
+                var buff = json
+                var pieces = embed_key[provider].split('.')
+                for (var i = 0; i < pieces.length; i++) {
                   if (buff.hasOwnProperty(pieces[i])) {
-                    buff = buff[pieces[i]];
-                  }
-                  else {
-                    buff = false;
+                    buff = buff[pieces[i]]
+                  } else {
+                    buff = false
                   }
                 }
                 if (buff !== false) {
-                  html = buff;
+                  html = buff
                 }
               }
             }
-          }
-          else if(editor.config.iframely.method === 'oembed') {
+          } else if (editor.config.iframely.method === 'oembed') {
             if (typeof json.provider_name !== 'undefined') {
-              provider = json.provider_name.toLowerCase();
+              provider = json.provider_name.toLowerCase()
             }
           }
 
-          var embed = editor.document.createElement( 'div' );
-          var classes = ['iframely-embed'];
+          var embed = editor.document.createElement('div')
+          var classes = ['iframely-embed']
 
           if (provider !== '') {
-
-            var provider_class = provider.split(' ').join('-');
-
-            classes.push(classes[0] + '-' + provider_class);
+            classes.push(classes[0] + '-' + provider.split(' ').join('-'))
           }
 
-          embed.setAttribute(
-            'class',
-            classes.join(' ')
-          );
-
-          embed.appendHtml( html );
-
-          editor.insertElement( embed );
-        });
-
-
+          embed.setAttribute('class', classes.join(' '))
+          embed.appendHtml(html)
+          editor.insertElement(embed)
+        })
       }
-    };
-  });
-
-})();
+    }
+  })
+})()

--- a/dialogs/iframely.js
+++ b/dialogs/iframely.js
@@ -69,72 +69,64 @@
         }
 
         endpoint += '?' + query.join('&');
+        jQuery.get(endpoint, function(json) {
+          var html = json.html;
 
-        var xmlHttp = null;
-        xmlHttp = new XMLHttpRequest();
-        xmlHttp.open( 'GET', endpoint, false );
-        xmlHttp.send( null );
+          if (editor.config.iframely.method === 'iframely') {
+            if (typeof json.meta.site !== 'undefined') {
+              provider = json.meta.site.toLowerCase();
+            }
+            else {
+              if (typeof json.meta.author !== 'undefined') {
+                provider = json.meta.author.toLowerCase();
+              }
+            }
 
-        if (xmlHttp.status !== 200) {
-          return;
-        }
-
-        var json = JSON.parse(xmlHttp.responseText);
-        var html = json.html;
-
-        if (editor.config.iframely.method === 'iframely') {
-          if (typeof json.meta.site !== 'undefined') {
-            provider = json.meta.site.toLowerCase();
+            if (typeof editor.config.iframely.embed_key !== 'undefined') {
+              var embed_key = editor.config.iframely.embed_key;
+              if (embed_key.hasOwnProperty(provider)) {
+                var buff = json;
+                var pieces = embed_key[provider].split(".");
+                for(var i=0; i< pieces.length; i++) {
+                  if (buff.hasOwnProperty(pieces[i])) {
+                    buff = buff[pieces[i]];
+                  }
+                  else {
+                    buff = false;
+                  }
+                }
+                if (buff !== false) {
+                  html = buff;
+                }
+              }
+            }
           }
-          else {
-            if (typeof json.meta.author !== 'undefined') {
-              provider = json.meta.author.toLowerCase();
+          else if(editor.config.iframely.method === 'oembed') {
+            if (typeof json.provider_name !== 'undefined') {
+              provider = json.provider_name.toLowerCase();
             }
           }
 
-          if (typeof editor.config.iframely.embed_key !== 'undefined') {
-            var embed_key = editor.config.iframely.embed_key;
-            if (embed_key.hasOwnProperty(provider)) {
-               var buff = json;
-               var pieces = embed_key[provider].split(".");
-               for(var i=0; i< pieces.length; i++) {
-                 if (buff.hasOwnProperty(pieces[i])) {
-                   buff = buff[pieces[i]];
-                 }
-                 else {
-                   buff = false;
-                 }
-               }
-               if (buff !== false) {
-                 html = buff;
-               }
-            }
+          var embed = editor.document.createElement( 'div' );
+          var classes = ['iframely-embed'];
+
+          if (provider !== '') {
+
+            var provider_class = provider.split(' ').join('-');
+
+            classes.push(classes[0] + '-' + provider_class);
           }
-        }
-        else if(editor.config.iframely.method === 'oembed') {
-          if (typeof json.provider_name !== 'undefined') {
-            provider = json.provider_name.toLowerCase();
-          }
-        }
 
-        var embed = editor.document.createElement( 'div' );
-        var classes = ['iframely-embed'];
+          embed.setAttribute(
+            'class',
+            classes.join(' ')
+          );
 
-        if (provider !== '') {
+          embed.appendHtml( html );
 
-          var provider_class = provider.split(' ').join('-');
+          editor.insertElement( embed );
+        });
 
-          classes.push(classes[0] + '-' + provider_class);
-        }
-
-        embed.setAttribute(
-          'class',
-          classes.join(' ')
-        );
-
-        embed.appendHtml( html );
-
-        editor.insertElement( embed );
 
       }
     };


### PR DESCRIPTION
#### What's this PR do?
Converts the iFramely insert iframe dialog handler from a synchronous callback to an an asynchronous one. 

#### How should this be manually tested?
This change is a needed dependency for [iFramely API Key issue](https://github.com/attn/publisher/pull/835) so testing should occur against that branch.

- Manually copy over the **dialogs/iframely.js** to the Publisher build artifact location (**./build/profiles/attn/libraries/ckeditor-plugins/iframely/dialogs/iframely.js** in the Publisher repo).
- Create a new story 
- Attempt to embed a tweet (e.g. https://twitter.com/Interior/status/463440424141459456) or another resource via iframely embed
  - [ ] Confirm the iframe was correctly inserted into the WYSIWYG.

#### Any background context you want to provide?
The previous version of the plugin relies on a synchronous XHR request which has been removed from most browsers. 

See the comments in [publisher#835](https://github.com/attn/publisher/pull/835) for more context.

#### What are the relevant tickets?
Refer to tickets in [publisher#835](https://github.com/attn/publisher/pull/835).

#### Screenshots:

#### Questions:

